### PR TITLE
modified old delete, added edit functionality for categories

### DIFF
--- a/src/components/Categories/CategoryLine.js
+++ b/src/components/Categories/CategoryLine.js
@@ -1,9 +1,35 @@
-export const CategoryLine = ({label}) => {
+import { useState } from "react"
+import { deleteCategory, editCategory } from "../Repos/CategoriesRepository"
+
+export const CategoryLine = ({ cat, sync }) => {
+    const [editing, setEditing] = useState(false)
+    const [cate, setCate] = useState(cat)
+    const updateCate = (e) => {
+        const copy = cate
+        copy[e.target.name] = e.target.value //could do with a useRef in theory
+        setCate(copy)
+    }
+    const flipEdit = () => setEditing(!editing)
+
     return <>
         <div>
-            <text>{label}</text>
-            <button className="button is-link" type="submit" >edit</button>
-            <button className="button is-link is-light" type="submit" >delete</button>
+            {editing ?
+                <div className="field">
+                    <label className="label">New Label: (previously {`${cat.label}`})</label>
+                    <div className="control">
+                        <input className="input" type="text" name="label" onChange={updateCate}/>
+                    </div>
+                    <button className="button is-link" type="submit" onClick={() => {
+                        editCategory(cate).then(sync)
+                        flipEdit()
+                    }
+                    }>Save</button>
+                </div> : <>
+                    <text>{cat.label}</text>
+                    <button className="button is-link" type="submit" onClick={flipEdit}>edit</button>
+                </>
+            }
+            <button className="button is-link is-light" type="submit" onClick={() => deleteCategory(cat.id).then(sync)}>delete</button>
         </div>
     </>
 }

--- a/src/components/Categories/CategoryList.js
+++ b/src/components/Categories/CategoryList.js
@@ -18,7 +18,7 @@ export const CategoryList = () => {
     return <section className="flexside">
         <div>
             <h3>Categories</h3>
-            {categories.map(category => <CategoryLine key={`category_${category.id}`}label={category.label} />)}
+            {categories.map(category => <CategoryLine key={`category_${category.id}`}cat={category} sync={syncCategories}/>)}
         </div>
         <CreateCategory sync={syncCategories}/>
     </section>

--- a/src/components/Repos/CategoriesRepository.js
+++ b/src/components/Repos/CategoriesRepository.js
@@ -19,7 +19,27 @@ export const addCategory = category => {
     }).then(getCategories)
 }
 
+export const editCategory = category => {
+    return fetch(`http://localhost:8000/categories/${category.id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("token")}`
+        },
+        body: JSON.stringify(category)
+    })
+}
+
 export const getPostsByCategory = (id) => {
     return fetch(`http://localhost:8000/posts?category_id=${id}`)
     .then(res => res.json())
+}
+
+export const deleteCategory = (id) => {
+    return fetch(`http://localhost:8000/categories/${id}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("token")}`
+        }
+    })
 }


### PR DESCRIPTION
# Description

Modified old delete method to work with new server. added functinoality to the edit button, including toggling between edit and non-edit states

Fixes # 16 17 client side

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

requires rare-api branch sd-categorycompletion for functionality

- [ ] Run a delete from category management. should live update
- [ ] select edit on a category, type in a new label, and hit save. should live update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
